### PR TITLE
FUCK SSH2 EXTENSION.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
 		}
 	],
 	"require": {
-		"jaz303/phake": "dev-master"
+		"jaz303/phake": "dev-master",
+		"phpseclib/phpseclib": "dev-master"
 	},
 	"autoload": {
 		"psr-0": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,5 +1,5 @@
 {
-    "hash": "4cb7fd704b96bbd2e522f37edcd52915",
+    "hash": "31851c878f60a9c050bf1a9b3f84f1b9",
     "packages": [
         {
             "name": "jaz303/phake",
@@ -23,7 +23,6 @@
                 "bin/phake"
             ],
             "type": "library",
-            "installation-source": "source",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
@@ -40,6 +39,72 @@
                 "cli",
                 "Tasks"
             ]
+        },
+        {
+            "name": "phpseclib/phpseclib",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/phpseclib",
+                "reference": "ce22f11f7f9ef3bb07f98e44e329446c4a667566"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/phpseclib/phpseclib/archive/ce22f11f7f9ef3bb07f98e44e329446c4a667566.zip",
+                "reference": "ce22f11f7f9ef3bb07f98e44e329446c4a667566",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.0.0"
+            },
+            "suggest": {
+                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a wide variety of cryptographic operations.",
+                "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
+                "pear-pear/PHP_Compat": "Install PHP_Compat to get phpseclib working on PHP >= 4.3.3."
+            },
+            "time": "2013-01-17 15:58:23",
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Crypt": "phpseclib/",
+                    "File": "phpseclib/",
+                    "Math": "phpseclib/",
+                    "Net": "phpseclib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "phpseclib/"
+            ],
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jim Wigginton",
+                    "email": "terrafrost@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
+            "homepage": "http://phpseclib.sourceforge.net",
+            "keywords": [
+                "security",
+                "cryptography",
+                "ssh",
+                "encryption",
+                "crypto",
+                "signature",
+                "signing",
+                "rsa",
+                "aes",
+                "sftp",
+                "x509",
+                "x.509",
+                "asn1",
+                "asn.1",
+                "BigInteger"
+            ]
         }
     ],
     "packages-dev": null,
@@ -48,6 +113,7 @@
     ],
     "minimum-stability": "dev",
     "stability-flags": {
-        "jaz303/phake": 20
+        "jaz303/phake": 20,
+        "phpseclib/phpseclib": 20
     }
 }

--- a/lib/Pomander/Environment.php
+++ b/lib/Pomander/Environment.php
@@ -97,6 +97,7 @@ class Environment
 		$this->role($role);
 		foreach($app->top_level_tasks as $task_name)
 		{
+			if(!in_array($task_name, $app->get_task_list())) continue;
 			if( in_array($role,$app->resolve($task_name)->dependencies()) )
 				return $this->inject_multi_role_after($role,$task_name);
 			else
@@ -115,10 +116,10 @@ class Environment
 		if(!$this->target) return exec_cmd($cmd);
 		if(!$this->shell)
 		{
-			$host = $this->user? "{$this->user}@{$this->target}" : $this->target;
-			$this->shell = new RemoteShell($host);
+			$auth = is_null($this->password)? $this->key_path : $this->password;
+			$user = is_null($this->user)? get_current_user : $this->user;
+			$this->shell = new RemoteShell($this->target, $user, $auth);
 		}
-
 		return $this->shell->run($cmd);
 	}
 
@@ -155,8 +156,10 @@ class Environment
 			"db"=>"",
 			"scm"=>"git",
 			"adapter"=>"mysql",
-			"rsync_cmd"=>"rsync",
 			"umask"=>"002",
+			"key_path"=>home()."/.ssh/id_rsa",
+			"password"=>null,
+			"rsync_cmd"=>"rsync",
 			"rsync_flags"=>"-avuzPO --quiet",
 			"db_backup_flags"=>"--lock-tables=FALSE --skip-add-drop-table | sed -e 's|INSERT INTO|REPLACE INTO|' -e 's|CREATE TABLE|CREATE TABLE IF NOT EXISTS|'",
 			"db_swap_url"=>true
@@ -186,6 +189,7 @@ class Environment
 
 	private function inject_multi_role_after($role,$task_name)
 	{
+		info("injecting after $task_name");
 		after($task_name,function($app) use($task_name,$role) {
 			if( $app->env->next_role($role) )
 			{

--- a/lib/Pomander/RemoteShell.php
+++ b/lib/Pomander/RemoteShell.php
@@ -3,18 +3,65 @@ namespace Pomander;
 
 class RemoteShell
 {
-	protected $host;
+	protected $host, $user, $auth, $shell;
 
-	public function __construct($host)
+	public function __construct($host, $user, $auth)
 	{
 		$this->host = $host;
+		$this->user = $user;
+		$this->auth = $auth;
+		$this->connect();
 	}
 
 	public function run($cmd)
 	{
-		$status = 0;
-		$output = array();
-		exec("ssh {$this->host} \"$cmd\"", $output, $status);
-		return array($status, $output);	
+		$this->shell->exec($cmd);
+
+		$status = -1;
+		$output = '';
+		while ($status < 0) {
+			$temp = $this->shell->_get_channel_packet(NET_SSH2_CHANNEL_EXEC);
+			if($temp === true) $status = 0;
+			elseif($temp === false) $status = 1;
+			else
+			{
+				$output .= $temp;
+				$this->handle_data($temp);
+			}
+		}
+		$status = isset($this->shell->exit_status)? $this->shell->exit_status : $status;
+		return array($status, array_filter(explode("\n",$output), 'trim'));
+	}
+
+	public function write($cmd)
+	{
+		$this->shell->_send_channel_packet(NET_SSH2_CHANNEL_EXEC, "$cmd\n");
+	}
+
+/* protected */
+	protected function connect()
+	{
+		//TODO: Support other ports
+		$this->shell = new SSH2($this->host);
+		if(file_exists($this->auth))
+		{
+			$key = new \Crypt_RSA();
+			$key_status = $key->loadKey(file_get_contents($this->auth));
+			if(!$key_status) abort("ssh", "Unable to load RSA key.");
+		}else
+		{
+			$key = $this->auth;
+		}
+
+		if(!$this->shell->login($this->user, $key))
+			abort("ssh", "Login failed.");
+	}
+
+	protected function handle_data($output)
+	{
+		if(preg_match('/(The authenticity of host .* \(yes\/no\))/s', $output))
+		{
+			$this->write("yes");
+		}
 	}
 }

--- a/lib/Pomander/SSH2.php
+++ b/lib/Pomander/SSH2.php
@@ -1,0 +1,250 @@
+<?php
+namespace Pomander;
+
+class SSH2 extends \Net_SSH2
+{
+	public function exec($command, $block = false)
+	{
+		$this->curTimeout = $this->timeout;
+
+		if (!($this->bitmap & NET_SSH2_MASK_LOGIN)) {
+				return false;
+		}
+
+		// RFC4254 defines the (client) window size as "bytes the other party can send before it must wait for the window to
+		// be adjusted".  0x7FFFFFFF is, at 4GB, the max size.  technically, it should probably be decremented, but, 
+		// honestly, if you're transfering more than 4GB, you probably shouldn't be using phpseclib, anyway.
+		// see http://tools.ietf.org/html/rfc4254#section-5.2 for more info
+		$this->window_size_client_to_server[NET_SSH2_CHANNEL_EXEC] = 0x7FFFFFFF;
+		// 0x8000 is the maximum max packet size, per http://tools.ietf.org/html/rfc4253#section-6.1, although since PuTTy
+		// uses 0x4000, that's what will be used here, as well.
+		$packet_size = 0x4000;
+
+		$packet = pack('CNa*N3',
+			NET_SSH2_MSG_CHANNEL_OPEN, strlen('session'), 'session', NET_SSH2_CHANNEL_EXEC, $this->window_size_client_to_server[NET_SSH2_CHANNEL_EXEC], $packet_size);
+
+		if (!$this->_send_binary_packet($packet)) {
+			return false;
+		}
+
+		$this->channel_status[NET_SSH2_CHANNEL_EXEC] = NET_SSH2_MSG_CHANNEL_OPEN;
+
+		$response = $this->_get_channel_packet(NET_SSH2_CHANNEL_EXEC);
+		if ($response === false) {
+			return false;
+		}
+
+		//send request-pty
+		$terminal_modes = pack('C', NET_SSH2_TTY_OP_END);
+		$packet = pack('CNNa*CNa*N5a*',
+			NET_SSH2_MSG_CHANNEL_REQUEST, $this->server_channels[NET_SSH2_CHANNEL_EXEC], strlen('pty-req'), 'pty-req', 1, strlen('vt100'), 'vt100',
+			80, 24, 0, 0, strlen($terminal_modes), $terminal_modes);
+
+		if (!$this->_send_binary_packet($packet)) {
+			return false;
+		}
+		$response = $this->_get_binary_packet();
+		if ($response === false) {
+			user_error('Connection closed by server');
+			return false;
+		}
+
+		list(, $type) = unpack('C', $this->_string_shift($response, 1));
+
+		switch ($type) {
+			case NET_SSH2_MSG_CHANNEL_SUCCESS:
+				break;
+			case NET_SSH2_MSG_CHANNEL_FAILURE:
+			default:
+				user_error('Unable to request pseudo-terminal');
+				return $this->_disconnect(NET_SSH2_DISCONNECT_BY_APPLICATION);
+		}
+
+		$packet = pack('CNNa*CNa*',
+			NET_SSH2_MSG_CHANNEL_REQUEST, $this->server_channels[NET_SSH2_CHANNEL_EXEC], strlen('exec'), 'exec', 1, strlen($command), $command);
+		if (!$this->_send_binary_packet($packet)) {
+			return false;
+		}
+
+		$this->channel_status[NET_SSH2_CHANNEL_EXEC] = NET_SSH2_MSG_CHANNEL_REQUEST;
+
+		$response = $this->_get_channel_packet(NET_SSH2_CHANNEL_EXEC);
+		if ($response === false) {
+			return false;
+		}
+
+		$this->channel_status[NET_SSH2_CHANNEL_EXEC] = NET_SSH2_MSG_CHANNEL_DATA;
+
+		if (!$block) {
+			return true;
+		}
+
+		$output = '';
+		while (true) {
+			$temp = $this->_get_channel_packet(NET_SSH2_CHANNEL_EXEC);
+			switch (true) {
+				case $temp === true:
+					return $output;
+				case $temp === false:
+					return false;
+				default:
+					$output.= $temp;
+			}
+		}
+	}
+
+
+	function _get_channel_packet($client_channel, $skip_extended = false)
+	{
+		if (!empty($this->channel_buffers[$client_channel])) {
+			return array_shift($this->channel_buffers[$client_channel]);
+		}
+
+		while (true) {
+			if ($this->curTimeout) {
+				$read = array($this->fsock);
+				$write = $except = NULL;
+
+				$start = strtok(microtime(), ' ') + strtok(''); // http://php.net/microtime#61838
+				$sec = floor($this->curTimeout);
+				$usec = 1000000 * ($this->curTimeout - $sec);
+				// on windows this returns a "Warning: Invalid CRT parameters detected" error
+				if (!@stream_select($read, $write, $except, $sec, $usec) && !count($read)) {
+					$this->_close_channel($client_channel);
+					return true;
+				}
+				$elapsed = strtok(microtime(), ' ') + strtok('') - $start;
+				$this->curTimeout-= $elapsed;
+			}
+
+			$response = $this->_get_binary_packet();
+			if ($response === false) {
+				user_error('Connection closed by server');
+				return false;
+			}
+
+			if (!strlen($response)) {
+				return '';
+			}
+
+			extract(unpack('Ctype/Nchannel', $this->_string_shift($response, 5)));
+
+			switch ($this->channel_status[$channel]) {
+				case NET_SSH2_MSG_CHANNEL_OPEN:
+					switch ($type) {
+						case NET_SSH2_MSG_CHANNEL_OPEN_CONFIRMATION:
+							extract(unpack('Nserver_channel', $this->_string_shift($response, 4)));
+							$this->server_channels[$channel] = $server_channel;
+							$this->_string_shift($response, 4); // skip over (server) window size
+							$temp = unpack('Npacket_size_client_to_server', $this->_string_shift($response, 4));
+							$this->packet_size_client_to_server[$channel] = $temp['packet_size_client_to_server'];
+							return $client_channel == $channel ? true : $this->_get_channel_packet($client_channel, $skip_extended);
+						//case NET_SSH2_MSG_CHANNEL_OPEN_FAILURE:
+						default:
+							user_error('Unable to open channel');
+							return $this->_disconnect(NET_SSH2_DISCONNECT_BY_APPLICATION);
+					}
+					break;
+				case NET_SSH2_MSG_CHANNEL_REQUEST:
+					switch ($type) {
+						case NET_SSH2_MSG_CHANNEL_SUCCESS:
+							return true;
+						//case NET_SSH2_MSG_CHANNEL_FAILURE:
+						default:
+							user_error('Unable to request pseudo-terminal');
+							return $this->_disconnect(NET_SSH2_DISCONNECT_BY_APPLICATION);
+					}
+				case NET_SSH2_MSG_CHANNEL_CLOSE:
+					return $type == NET_SSH2_MSG_CHANNEL_CLOSE ? true : $this->_get_channel_packet($client_channel, $skip_extended);
+			}
+
+			switch ($type) {
+				case NET_SSH2_MSG_CHANNEL_DATA:
+					/*
+					if ($client_channel == NET_SSH2_CHANNEL_EXEC) {
+							// SCP requires null packets, such as this, be sent.  further, in the case of the ssh.com SSH server
+							// this actually seems to make things twice as fast.  more to the point, the message right after 
+							// SSH_MSG_CHANNEL_DATA (usually SSH_MSG_IGNORE) won't block for as long as it would have otherwise.
+							// in OpenSSH it slows things down but only by a couple thousandths of a second.
+							$this->_send_channel_packet($client_channel, chr(0));
+					}
+					*/
+					extract(unpack('Nlength', $this->_string_shift($response, 4)));
+					$data = $this->_string_shift($response, $length);
+					if ($client_channel == $channel) {
+						return $data;
+					}
+					if (!isset($this->channel_buffers[$client_channel])) {
+						$this->channel_buffers[$client_channel] = array();
+					}
+					$this->channel_buffers[$client_channel][] = $data;
+					break;
+				case NET_SSH2_MSG_CHANNEL_EXTENDED_DATA:
+					if ($skip_extended || $this->quiet_mode) {
+						break;
+					}
+					/*
+					if ($client_channel == NET_SSH2_CHANNEL_EXEC) {
+							$this->_send_channel_packet($client_channel, chr(0));
+					}
+					*/
+					// currently, there's only one possible value for $data_type_code: NET_SSH2_EXTENDED_DATA_STDERR
+					extract(unpack('Ndata_type_code/Nlength', $this->_string_shift($response, 8)));
+					$data = $this->_string_shift($response, $length);
+					if ($client_channel == $channel) {
+						return $data;
+					}
+					if (!isset($this->channel_buffers[$client_channel])) {
+						$this->channel_buffers[$client_channel] = array();
+					}
+					$this->channel_buffers[$client_channel][] = $data;
+					break;
+				case NET_SSH2_MSG_CHANNEL_REQUEST:
+					extract(unpack('Nlength', $this->_string_shift($response, 4)));
+					$value = $this->_string_shift($response, $length);
+					switch ($value) {
+						case 'exit-signal':
+							$this->_string_shift($response, 1);
+							extract(unpack('Nlength', $this->_string_shift($response, 4)));
+							$this->errors[] = 'SSH_MSG_CHANNEL_REQUEST (exit-signal): ' . $this->_string_shift($response, $length);
+							$this->_string_shift($response, 1);
+							extract(unpack('Nlength', $this->_string_shift($response, 4)));
+							if ($length) {
+									$this->errors[count($this->errors)].= "\r\n" . $this->_string_shift($response, $length);
+							}
+						case 'exit-status':
+							extract(unpack('Cfalse/Nexit_status', $this->_string_shift($response, 5)));
+							$this->exit_status = $exit_status;
+							// "The channel needs to be closed with SSH_MSG_CHANNEL_CLOSE after this message."
+							// -- http://tools.ietf.org/html/rfc4254#section-6.10
+							$this->_send_binary_packet(pack('CN', NET_SSH2_MSG_CHANNEL_EOF, $this->server_channels[$client_channel]));
+							$this->_send_binary_packet(pack('CN', NET_SSH2_MSG_CHANNEL_CLOSE, $this->server_channels[$channel]));
+
+							$this->channel_status[$channel] = NET_SSH2_MSG_CHANNEL_EOF;
+						default:
+							// "Some systems may not implement signals, in which case they SHOULD ignore this message."
+							//  -- http://tools.ietf.org/html/rfc4254#section-6.9
+							break;
+					}
+					break;
+				case NET_SSH2_MSG_CHANNEL_CLOSE:
+					$this->curTimeout = 0;
+
+					if ($this->bitmap & NET_SSH2_MASK_SHELL) {
+						$this->bitmap&= ~NET_SSH2_MASK_SHELL;
+					}
+					if ($this->channel_status[$channel] != NET_SSH2_MSG_CHANNEL_EOF) {
+						$this->_send_binary_packet(pack('CN', NET_SSH2_MSG_CHANNEL_CLOSE, $this->server_channels[$channel]));
+					}
+
+					$this->channel_status[$channel] = NET_SSH2_MSG_CHANNEL_CLOSE;
+					return true;
+				case NET_SSH2_MSG_CHANNEL_EOF:
+					break;
+				default:
+					user_error('Error reading channel data');
+					return $this->_disconnect(NET_SSH2_DISCONNECT_BY_APPLICATION);
+			}
+		}
+	}
+}


### PR DESCRIPTION
the SSH2 extension, like `proc_open`, is garbage. So many bugs that I dropped it completely.

This pull request goes BACK to using phpseclib with some modifications:
1. send request-pty bits in $ssh->exec() to get a pty. woo!
2. return the exit status of the ssh command.

Things like host key checking work wonderfully.
