### PR TITLE
#19 - Fixes key password variable naming

### DIFF
--- a/lib/Pomander/Environment.php
+++ b/lib/Pomander/Environment.php
@@ -118,7 +118,7 @@ class Environment
 		if(!$this->target) return exec_cmd($cmd);
 		if(!$this->shell)
 		{
-			$keypass = $this->key_pass;
+			$keypass = $this->key_password;
 			$auth = is_null($this->password)? $this->key_path : $this->password;
 			$user = is_null($this->user)? get_current_user : $this->user;
 			$this->shell = new RemoteShell($this->target, $this->port, $user, $auth, $keypass);


### PR DESCRIPTION
Hi @williamn,

I'm sorry, I made some tests some time ago then got busy and forgot to report any feedback.

I managed to connect using phpseclib in a "standalone" way. I debugged to see where was located the problem. Actually, it's just a naming variable problem as you can see in my pull request. 
