### PR TITLE
 Composer install with "--prefer-dist" option

### DIFF
--- a/lib/tasks/composer.php
+++ b/lib/tasks/composer.php
@@ -9,7 +9,7 @@ group('composer', function () {
         run(array(
             "cd {$app->env->release_dir}",
             "([ -e 'composer.json' ] && which composer &>/dev/null)",
-            "composer install --optimize-autoloader || echo '    composer.json not found'"
+            "composer install --prefer-dist --optimize-autoloader || echo '    composer.json not found'"
         ));
     });
 


### PR DESCRIPTION
I have noticed that in most cases dependencies of my project are not changes.
If Composer works with dists it can use cache and reduce deploy time.
I suggest use this ability in Pomander.
