### PR TITLE
Deploy in an existing directory

### DIFF
--- a/lib/Pomander/Scm/Git.php
+++ b/lib/Pomander/Scm/Git.php
@@ -18,15 +18,17 @@ class Git extends Scm
     {
         $cmd = array();
 
-        $cmd[] = "cd {$location}";
-        $cmd[] = "rm -rf .git";
-        $cmd[] = "rm -rf REVISION";
-        $cmd[] = "git init -q";
-        $cmd[] = "git remote add origin {$this->repository}";
-        $cmd[] = "git fetch origin -q";
-        $cmd[] = "git reset --hard origin/master -q";
+        $cmd[] = "umask {$this->app->env->umask}";
+        $cmd[] = "if test ! -d {$location}; then mkdir {$location}; fi";
 
-        return implode(' && ', $cmd);
+        $cmd[] = "rm -rf {$location}/*";
+        $cmd[] = "cd {$location}";
+        $cmd[] = "git init -q";
+
+        $remote = isset($this->app->env->remote)? $this->app->env->remote : "origin";
+        $cmd[] = "git remote add {$remote} {$this->repository}";
+
+        return implode(' && ', $cmd) . ' && ' . $this->update();
     }
 
     /**

--- a/lib/tasks/deploy.php
+++ b/lib/tasks/deploy.php
@@ -5,10 +5,6 @@ group('deploy', function () {
     desc("Setup application in environment.");
     task('setup','app', function ($app) {
         info("deploy","setting up environment");
-        $cmd = array(
-            "umask {$app->env->umask}",
-            "if test ! -d {$app->env->deploy_to}; then mkdir -p {$app->env->deploy_to}; fi"
-        );
 
         if ($app->env->releases === false) {
             $cmd[] = $app->env->scm->create($app->env->deploy_to);


### PR DESCRIPTION
Hi Mike, 
I made ​​a change for authorized to clone in a directory that already exists. This need appears if the directory is an NFS mount (with Vagrant for example). You can not remove this mount point :(
Thank you
