### PR TITLE
fixed a bug where setting an environment config via magic method (i.e.

### DIFF
--- a/lib/Pomander/Environment.php
+++ b/lib/Pomander/Environment.php
@@ -50,7 +50,11 @@ class Environment
 
     public function __call($name, $arguments)
     {
-        $this->$name = array_shift($arguments);
+        if (array_key_exists($name, get_object_vars($this))) {
+            $this->config[$name] = array_shift($arguments);
+        } else {
+            $this->$name = array_shift($arguments);
+        }
 
         return $this;
     }


### PR DESCRIPTION
scm('svn')) where an instance variable already existed would fail. #53
