### PR TITLE
Show failure reasons

### DIFF
--- a/lib/Pomander/RemoteShell.php
+++ b/lib/Pomander/RemoteShell.php
@@ -3,7 +3,14 @@ namespace Pomander;
 
 class RemoteShell
 {
-    protected $host, $port, $user, $auth, $shell, $key_pass;
+    /**
+     * SSH
+     *
+     * @var \Net_SSH2
+     */
+    protected $shell;
+
+    protected $host, $port, $user, $auth, $key_pass;
 
     public function __construct($host, $port, $user, $auth, $key_pass)
     {
@@ -52,6 +59,11 @@ class RemoteShell
             abort("ssh", "Login failed.");
     }
 
+    /**
+     * Process remote command execution
+     *
+     * @return string
+     */
     protected function process()
     {
         $output = "";
@@ -61,9 +73,8 @@ class RemoteShell
             $temp = $this->shell->_get_channel_packet(NET_SSH2_CHANNEL_EXEC);
             switch( true ) {
                 case $temp === true:
-                    return $output;
                 case $temp === false:
-                    return false;
+                    return $output;
                 default:
                     $output .= $temp;
                     if( $this->handle_data(substr($output, $offset)) ) {


### PR DESCRIPTION
Currently when remote command execution fails pomander show no error output. Like this:
```
 * info deploy:after some foo action
 * warn fail Rolling back...
```
This PR change this behavior to something like this:
```
 * info deploy:after some foo action
Warning: require(/var/www/develop/releases/20150506122507/app/../vendor/autoload.php): failed to open stream: No such file or directory in /var/www/develop/releases/20150506122507/app/autoload.php on line 9
 * warn fail Rolling back...
```
Which is more helpful.