### PR TITLE
Update phpseclib (PHP 7 compatibility)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "require": {
     "jaz303/phake": "~0.6",
-    "phpseclib/phpseclib": "~1.0"
+    "phpseclib/phpseclib": "^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "@stable"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3b752aec4febc6ff4b954becba41f3a3",
-    "content-hash": "2ebf2473b78fc6809db5336835ffc03c",
+    "hash": "85f678cea3059578b5ea0f6bbd171f78",
+    "content-hash": "224fa529c0b0ab18237a600d7fbd8afe",
     "packages": [
         {
             "name": "jaz303/phake",
@@ -54,20 +54,20 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "1.0.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "f60e365be28d9218b4bcdc0ab96ac7e338668f11"
+                "reference": "ba6fb78f727cd09f2a649113b95468019e490585"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/f60e365be28d9218b4bcdc0ab96ac7e338668f11",
-                "reference": "f60e365be28d9218b4bcdc0ab96ac7e338668f11",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/ba6fb78f727cd09f2a649113b95468019e490585",
+                "reference": "ba6fb78f727cd09f2a649113b95468019e490585",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.0.0"
+                "php": ">=5.3.3"
             },
             "require-dev": {
                 "phing/phing": "~2.7",
@@ -77,26 +77,17 @@
             },
             "suggest": {
                 "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
-                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a wide variety of cryptographic operations.",
-                "pear-pear/PHP_Compat": "Install PHP_Compat to get phpseclib working on PHP < 5.0.0."
+                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
+                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
+                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
             },
             "type": "library",
             "autoload": {
-                "psr-0": {
-                    "Crypt": "phpseclib/",
-                    "File": "phpseclib/",
-                    "Math": "phpseclib/",
-                    "Net": "phpseclib/",
-                    "System": "phpseclib/"
-                },
-                "files": [
-                    "phpseclib/Crypt/Random.php"
-                ]
+                "psr-4": {
+                    "phpseclib\\": "phpseclib/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                "phpseclib/"
-            ],
             "license": [
                 "MIT"
             ],
@@ -148,7 +139,7 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2016-01-18 17:07:12"
+            "time": "2016-01-18 17:07:21"
         }
     ],
     "packages-dev": [

--- a/lib/Pomander/RemoteShell.php
+++ b/lib/Pomander/RemoteShell.php
@@ -1,12 +1,15 @@
 <?php
 namespace Pomander;
 
+use phpseclib\Crypt\RSA;
+use phpseclib\Net\SSH2;
+
 class RemoteShell
 {
     /**
      * SSH
      *
-     * @var \Net_SSH2
+     * @var SSH2
      */
     protected $shell;
 
@@ -43,9 +46,9 @@ class RemoteShell
 /* protected */
     protected function connect()
     {
-        $this->shell = new \Net_SSH2($this->host, $this->port);
+        $this->shell = new SSH2($this->host, $this->port);
         if (file_exists($this->auth)) {
-            $key = new \Crypt_RSA();
+            $key = new RSA();
             if ($this->key_pass) {
                 $key->setPassword($this->key_pass);
             }
@@ -70,7 +73,7 @@ class RemoteShell
         $offset = 0;
         $this->shell->_initShell();
         while( true ) {
-            $temp = $this->shell->_get_channel_packet(NET_SSH2_CHANNEL_EXEC);
+            $temp = $this->shell->_get_channel_packet(SSH2::CHANNEL_EXEC);
             switch( true ) {
                 case $temp === true:
                 case $temp === false:


### PR DESCRIPTION
Fix `Methods with the same name as their class will not be constructors in a future version of PHP; Net_SSH2 has a deprecated constructor`
